### PR TITLE
fix(embed): use fixed-size chunks for decoding

### DIFF
--- a/crates/claw-embed/src/store.rs
+++ b/crates/claw-embed/src/store.rs
@@ -471,10 +471,8 @@ fn decode_vec(blob: &[u8], dim: usize) -> Result<Vec<f32>, SemanticError> {
         });
     }
     let mut out = Vec::with_capacity(dim);
-    for chunk in blob.chunks_exact(4) {
-        let mut buf = [0u8; 4];
-        buf.copy_from_slice(chunk);
-        out.push(f32::from_le_bytes(buf));
+    for chunk in blob.as_chunks::<4>().0 {
+        out.push(f32::from_le_bytes(*chunk));
     }
     Ok(out)
 }


### PR DESCRIPTION
## Summary

- use fixed-size slice chunks when decoding stored f32 vectors
- preserve byte order, vector length validation, and persistence format
- restore current stable Rust 1.98 clippy compatibility

## Validation

- `cargo test -p claw-embed --lib`
- `cargo clippy -p claw-embed --lib -- -D warnings`

Closes #50